### PR TITLE
reformat skills section - vertical instead of side by side

### DIFF
--- a/src/components/skills/Skills.css
+++ b/src/components/skills/Skills.css
@@ -8,7 +8,8 @@ ul {
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100vh;
+  height: fit-content;
+  overflow-x: hidden;
 }
 
 .Skills_container {
@@ -32,7 +33,7 @@ ul {
   flex-direction: column;
   align-items: center;
   height: 100%;
-  width: 50%;
+  width: 100%;
   background-color: var(--accent-2);
   color: var(--white-text);
 }
@@ -55,7 +56,7 @@ ul {
   flex-direction: column;
   align-items: center;
   height: 100%;
-  width: 50%;
+  width: 100%;
   background-color: var(--accent-1);
   color: var(--white-text);
 }
@@ -73,46 +74,17 @@ ul {
   font-size: 120%;
 }
 
-@media only screen and (max-width: 1100px) {
-  .Technical_skills h2 {
-    font-size: 2rem;
-  }
-
-  .Soft_skills h2 {
-    font-size: 2rem;
-  }
+@media only screen and (max-width: 850px) {
+ 
 
   .Skills_list {
     font-size: 1rem;
-    padding: 0;
   }
 }
 
-@media only screen and (max-width: 400px) {
+@media only screen and (min-height: 1100px) {
   .Skills {
-    height: 190vh;
-  }
-  
-    .Skills_container {
-    overflow-y: hidden;
-    overflow-x: none;
-    max-height: fit-content;
-  }
-  .Technical_skills h2 {
-    font-size: 1.6rem;
-  }
-
-  .Soft_skills h2 {
-    font-size: 1.6rem;
-  }
-
-  .Skills_list {
-    font-size: 0.9rem;
-    height: fit-content;
-    flex-direction: column;
-  }
-
-  .Technical_skills {
-    height: 100%;
+   height: 100vh;
   }
 }
+

--- a/src/components/skills/Skills.js
+++ b/src/components/skills/Skills.js
@@ -4,7 +4,6 @@ import "./Skills.css";
 function Skills() {
   return (
     <section className="Skills">
-      <div className="Skills_container">
         <div className="Technical_skills">
           <h2>Technical Skills</h2>
           <div className="Skills_list">
@@ -56,7 +55,7 @@ function Skills() {
               </ul>
           </div>
         </div>
-      </div>
+    
     </section>
   );
 }


### PR DESCRIPTION
Changed the layout of the skill section to have Tech and Soft in a vertical instead of a horizontal layout (relative to each other).

This made it a lot easier to deal with sizing on different screens.

Tested to ensure it worked on all screen sizes (according to the list I use in chrome dev tools).